### PR TITLE
Implement stechec2 GameState and Api refactor

### DIFF
--- a/src/action_agripper.cc
+++ b/src/action_agripper.cc
@@ -1,14 +1,14 @@
 #include "actions.hh"
 
-int ActionAgripper::check(const GameState* st) const
+int ActionAgripper::check(const GameState& st) const
 {
-    if (!st->is_init())
+    if (!st.is_init())
         FATAL("action: you cannot use action outside jouer_tour");
 
     if (id_nain_ < 0 || id_nain_ >= NB_NAINS)
         return ID_NAIN_INVALIDE;
 
-    const nain nain = st->get_nain(player_id_, id_nain_);
+    const nain nain = st.get_nain(player_id_, id_nain_);
 
     if (nain.vie <= 0)
         return NAIN_MORT;

--- a/src/action_agripper.hh
+++ b/src/action_agripper.hh
@@ -17,7 +17,7 @@ public:
     }
     ActionAgripper() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_debug_afficher_drapeau.cc
+++ b/src/action_debug_afficher_drapeau.cc
@@ -2,9 +2,9 @@
 
 #include "position.hh"
 
-int ActionDebugAfficherDrapeau::check(const GameState* st) const
+int ActionDebugAfficherDrapeau::check(const GameState& st) const
 {
-    if (!st->is_init())
+    if (!st.is_init())
         FATAL("action: you cannot use action outside jouer_tour");
 
     if (!inside_map(pos_))

--- a/src/action_debug_afficher_drapeau.hh
+++ b/src/action_debug_afficher_drapeau.hh
@@ -19,7 +19,7 @@ public:
     }
     ActionDebugAfficherDrapeau() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_deplacer.cc
+++ b/src/action_deplacer.cc
@@ -2,16 +2,16 @@
 
 #include "position.hh"
 
-int ActionDeplacer::check(const GameState* st) const
+int ActionDeplacer::check(const GameState& st) const
 {
-    if (!st->is_init())
+    if (!st.is_init())
         FATAL("action: you cannot use action outside jouer_tour");
 
     // Check dwarf
     if (id_nain_ < 0 || id_nain_ >= NB_NAINS)
         return ID_NAIN_INVALIDE;
 
-    const nain nain = st->get_nain(player_id_, id_nain_);
+    const nain nain = st.get_nain(player_id_, id_nain_);
     if (nain.vie <= 0)
         return NAIN_MORT;
 
@@ -24,15 +24,15 @@ int ActionDeplacer::check(const GameState* st) const
     if (!inside_map(dest))
         return HORS_LIMITES;
 
-    if (st->map().get_cell_type(dest) != LIBRE)
+    if (st.map().get_cell_type(dest) != LIBRE)
         return OBSTACLE_MUR;
 
-    int dest_owner = st->map().get_cell_occupant(dest);
-    if (dest_owner == st->get_opponent_id(player_id_))
+    int dest_owner = st.map().get_cell_occupant(dest);
+    if (dest_owner == st.get_opponent_id(player_id_))
         return OBSTACLE_NAIN;
 
     // Check cost
-    int cost = st->get_movement_cost(player_id_, id_nain_, dir_);
+    int cost = st.get_movement_cost(player_id_, id_nain_, dir_);
 
     if (nain.pm < cost)
         return PM_INSUFFISANTS;

--- a/src/action_deplacer.hh
+++ b/src/action_deplacer.hh
@@ -18,7 +18,7 @@ public:
     }
     ActionDeplacer() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_lacher.cc
+++ b/src/action_lacher.cc
@@ -1,14 +1,14 @@
 #include "actions.hh"
 
-int ActionLacher::check(const GameState* st) const
+int ActionLacher::check(const GameState& st) const
 {
-    if (!st->is_init())
+    if (!st.is_init())
         FATAL("action: you cannot use action outside jouer_tour");
 
     if (id_nain_ < 0 || id_nain_ >= NB_NAINS)
         return ID_NAIN_INVALIDE;
 
-    const nain nain = st->get_nain(player_id_, id_nain_);
+    const nain nain = st.get_nain(player_id_, id_nain_);
 
     if (nain.vie <= 0)
         return NAIN_MORT;

--- a/src/action_lacher.hh
+++ b/src/action_lacher.hh
@@ -17,7 +17,7 @@ public:
     }
     ActionLacher() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_miner.cc
+++ b/src/action_miner.cc
@@ -2,9 +2,9 @@
 
 #include "position.hh"
 
-int ActionMiner::check(const GameState* st) const
+int ActionMiner::check(const GameState& st) const
 {
-    if (!st->is_init())
+    if (!st.is_init())
         FATAL("action: you cannot use action outside jouer_tour");
 
     if (dir_ < 0 || dir_ >= 4)
@@ -14,7 +14,7 @@ int ActionMiner::check(const GameState* st) const
     if (id_nain_ < 0 || id_nain_ >= NB_NAINS)
         return ID_NAIN_INVALIDE;
 
-    const nain nain = st->get_nain(player_id_, id_nain_);
+    const nain nain = st.get_nain(player_id_, id_nain_);
     if (nain.vie <= 0)
         return NAIN_MORT;
 
@@ -27,12 +27,12 @@ int ActionMiner::check(const GameState* st) const
     if (!inside_map(dest))
         return HORS_LIMITES;
 
-    case_type type = st->map().get_cell_type(dest);
+    case_type type = st.map().get_cell_type(dest);
 
     if (type == OBSIDIENNE)
         return OBSTACLE_MUR;
 
-    if (type == LIBRE && st->map().get_cell_occupant(dest) == -1)
+    if (type == LIBRE && st.map().get_cell_occupant(dest) == -1)
         return PAS_DE_CIBLE;
 
     return OK;

--- a/src/action_miner.hh
+++ b/src/action_miner.hh
@@ -18,7 +18,7 @@ public:
     }
     ActionMiner() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_poser_corde.cc
+++ b/src/action_poser_corde.cc
@@ -2,9 +2,9 @@
 
 #include "position.hh"
 
-int ActionPoserCorde::check(const GameState* st) const
+int ActionPoserCorde::check(const GameState& st) const
 {
-    if (!st->is_init())
+    if (!st.is_init())
         FATAL("action: you cannot use action outside jouer_tour");
 
     if (dir_ < 0 || dir_ >= 4)
@@ -15,10 +15,10 @@ int ActionPoserCorde::check(const GameState* st) const
         return ID_NAIN_INVALIDE;
 
     for (int i = 0; i < NB_NAINS; ++i)
-        if (st->get_nain(player_id_, i).pa != NB_POINTS_ACTION)
+        if (st.get_nain(player_id_, i).pa != NB_POINTS_ACTION)
             return PA_INSUFFISANTS;
 
-    const nain nain = st->get_nain(player_id_, id_nain_);
+    const nain nain = st.get_nain(player_id_, id_nain_);
     if (nain.vie <= 0)
         return NAIN_MORT;
 
@@ -28,10 +28,10 @@ int ActionPoserCorde::check(const GameState* st) const
     if (!inside_map(dest))
         return HORS_LIMITES;
 
-    if (st->map().has_rope_at(dest))
+    if (st.map().has_rope_at(dest))
         return OBSTACLE_CORDE;
 
-    if (st->map().get_cell_type(dest) != LIBRE)
+    if (st.map().get_cell_type(dest) != LIBRE)
         return OBSTACLE_MUR;
 
     return OK;

--- a/src/action_poser_corde.hh
+++ b/src/action_poser_corde.hh
@@ -18,7 +18,7 @@ public:
     }
     ActionPoserCorde() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/action_tirer.cc
+++ b/src/action_tirer.cc
@@ -4,16 +4,16 @@
 
 #include "position.hh"
 
-int ActionTirer::check(const GameState* st) const
+int ActionTirer::check(const GameState& st) const
 {
-    if (!st->is_init())
+    if (!st.is_init())
         FATAL("action: you cannot use action outside jouer_tour");
 
     // Check nain
     if (id_nain_ < 0 || id_nain_ >= NB_NAINS)
         return ID_NAIN_INVALIDE;
 
-    const nain nain = st->get_nain(player_id_, id_nain_);
+    const nain nain = st.get_nain(player_id_, id_nain_);
 
     if (nain.vie <= 0)
         return NAIN_MORT;
@@ -33,11 +33,11 @@ int ActionTirer::check(const GameState* st) const
     if (!inside_map(dest))
         return HORS_LIMITES;
 
-    if (st->map().get_cell_type(dest) != LIBRE)
+    if (st.map().get_cell_type(dest) != LIBRE)
         return OBSTACLE_MUR;
 
     // Check rope
-    if (!st->map().has_rope_at(dest))
+    if (!st.map().has_rope_at(dest))
         return PAS_DE_CORDE;
 
     return OK;

--- a/src/action_tirer.hh
+++ b/src/action_tirer.hh
@@ -19,7 +19,7 @@ public:
     }
     ActionTirer() {} // for register_action()
 
-    int check(const GameState* st) const override;
+    int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
 
     void handle_buffer(utils::Buffer& buf) override

--- a/src/api.hh
+++ b/src/api.hh
@@ -14,10 +14,12 @@
 #define API_HH_
 
 #include <rules/actions.hh>
+#include <rules/api.hh>
 #include <rules/game-state.hh>
 #include <rules/player.hh>
 #include <vector>
 
+#include "actions.hh"
 #include "constant.hh"
 #include "game_state.hh"
 #include "position.hh"
@@ -26,31 +28,12 @@
 ** The methods of this class are exported through 'interface.cc'
 ** to be called by the clients
 */
-class Api
+class Api : public rules::Api<GameState, erreur>
 {
-
 public:
-    Api(GameState* game_state, rules::Player_sptr player);
+    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
     virtual ~Api() {}
 
-    const rules::Player_sptr player() const { return player_; }
-    void player_set(rules::Player_sptr player) { player_ = player; }
-
-    rules::Actions* actions() { return &actions_; }
-
-    const GameState* game_state() const { return game_state_; }
-    GameState* game_state() { return game_state_; }
-    void game_state_set(rules::GameState* gs)
-    {
-        game_state_ = dynamic_cast<GameState*>(gs);
-    }
-
-private:
-    GameState* game_state_;
-    rules::Player_sptr player_;
-    rules::Actions actions_;
-
-public:
     /// Renvoie le plus court chemin entre deux positions de la mine sous la
     /// forme d'une suite de direction à emprunter. Si la position est invalide
     /// ou que le chemin n'existe pas, le chemin renvoyé est vide.
@@ -134,10 +117,6 @@ public:
 
     /// Renvoie le numéro de joueur de votre adversaire.
     int adversaire();
-
-    /// Annule la dernière action. Renvoie faux quand il n'y a pas d'action à
-    /// annuler ce tour ci.
-    bool annuler();
 
     /// Retourne le numéro du tour actuel.
     int tour_actuel();

--- a/src/dumper.cc
+++ b/src/dumper.cc
@@ -262,7 +262,7 @@ static void dump_stream(std::ostream& ss, const GameState& st)
 
 void Rules::dump_state(std::ostream& ss)
 {
-    dump_stream(ss, *api_->game_state());
+    dump_stream(ss, api_->game_state());
 }
 
 // from api.cc
@@ -274,7 +274,7 @@ extern "C" const char* dump_state_json()
     // return values by free-ing them.
     static std::string s;
     std::ostringstream ss;
-    dump_stream(ss, *api->game_state());
+    dump_stream(ss, api->game_state());
     s = ss.str();
     return s.c_str();
 }

--- a/src/game_state.cc
+++ b/src/game_state.cc
@@ -41,7 +41,7 @@ GameState::GameState(const GameState& st)
 {
 }
 
-rules::GameState* GameState::copy() const
+GameState* GameState::copy() const
 {
     return new GameState(*this);
 }

--- a/src/game_state.hh
+++ b/src/game_state.hh
@@ -16,8 +16,7 @@ class GameState : public rules::GameState
 {
 public:
     GameState(std::istream& map_stream, rules::Players_sptr players);
-    GameState(const GameState& st);
-    rules::GameState* copy() const override;
+    GameState* copy() const override;
 
     // Player ids manipulation
     int get_player_id(int player_key) const;
@@ -41,7 +40,7 @@ public:
 
     void check_rope_gravity(position pos, int current_player);
 
-    // Nain's ressources
+    // Nain's resources
     void reduce_pm(int player_id, int nain_id, int pm);
     void reset_pm(int player_id);
     void reduce_pa(int player_id, int nain_id, int pa);
@@ -61,7 +60,7 @@ public:
     int get_round() const;
     void increment_round();
 
-    // NOTE: usefull for the dumper
+    // NOTE: useful for the dumper
     const std::array<PlayerInfo, 2>& get_player_info() const;
 
     // History
@@ -77,6 +76,8 @@ public:
     void sync_score();
 
 private:
+    GameState(const GameState& st);
+
     int get_fall_distance(int player_id, int nain_id) const;
 
     std::array<PlayerInfo, 2> player_info_;

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -532,7 +532,7 @@ extern "C" int api_adversaire()
 /// annuler ce tour ci.
 extern "C" bool api_annuler()
 {
-    return api->annuler();
+    return api->cancel();
 }
 
 /// Retourne le numéro du tour actuel.

--- a/src/map.cc
+++ b/src/map.cc
@@ -378,7 +378,7 @@ std::vector<direction> Map::get_shortest_path(position start,
                     get_position_offset(source, (direction)dir);
 
                 if (id_occupant != -1 &&
-                        spawn_point_[1-id_occupant] == target)
+                    spawn_point_[1 - id_occupant] == target)
                     continue; // Ennemy's tavern here
                 if (inside_map(target) &&
                     predecessor[target.ligne][target.colonne] ==

--- a/src/rules.hh
+++ b/src/rules.hh
@@ -44,7 +44,7 @@ public:
 
     void dump_state(std::ostream& out) override;
 
-    GameState* get_game_state() const;
+    GameState& get_game_state() const;
 
 protected:
     f_champion_partie_init champion_partie_init_;

--- a/src/tests/test-action_miner.cc
+++ b/src/tests/test-action_miner.cc
@@ -39,16 +39,16 @@ TEST_F(ApiTest, ActionMiner_Recolte)
 
         for (int hit = 0; hit < 4; hit++)
         {
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
             EXPECT_EQ(OK, player.api->miner(nain_id, BAS));
             EXPECT_EQ(0, player.api->info_nain(player_id, nain_id).butin);
             EXPECT_EQ(nain.pos, player.api->info_nain(player_id, nain_id).pos);
         }
 
         // Break mineral
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
         EXPECT_EQ(OK, player.api->miner(nain_id, BAS));
         EXPECT_EQ(BUTIN_MAX, player.api->info_nain(player_id, nain_id).butin);
         EXPECT_EQ(nain_initial.pos.ligne + 2,
@@ -73,8 +73,8 @@ TEST_F(ApiTest, ActionMiner_Damage)
             for (int nain_id = 0; nain_id < NB_WARIORS; nain_id++)
                 EXPECT_EQ(OK, player.api->deplacer(nain_id, dir));
 
-            player.api->game_state()->reset_pm(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pm(
+                player.api->game_state().get_player_id(player_id));
         }
 
         for (int nain_id = 0; nain_id < NB_WARIORS; nain_id++)

--- a/src/tests/test-actions_corde.cc
+++ b/src/tests/test-actions_corde.cc
@@ -16,23 +16,23 @@ TEST_F(ApiTest, ActionPoserTirerCorde)
         for (int i = 0; i < 5; i++)
         {
             EXPECT_EQ(OK, player.api->deplacer(0, dir));
-            player.api->game_state()->reset_pm(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pm(
+                player.api->game_state().get_player_id(player_id));
         }
 
         for (int i = 0; i < 3; i++)
         {
             EXPECT_EQ(OK, player.api->miner(0, BAS));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
 
         // The second dwarf joins in the hole and grabs wall
         for (int i = 0; i < 5; i++)
         {
             EXPECT_EQ(OK, player.api->deplacer(1, dir));
-            player.api->game_state()->reset_pm(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pm(
+                player.api->game_state().get_player_id(player_id));
         }
 
         EXPECT_EQ(player.api->info_nain(player_id, 0).pos,
@@ -43,52 +43,52 @@ TEST_F(ApiTest, ActionPoserTirerCorde)
         for (int i = 0; i < 4; i++)
         {
             EXPECT_EQ(OK, player.api->deplacer(2, dir));
-            player.api->game_state()->reset_pm(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pm(
+                player.api->game_state().get_player_id(player_id));
         }
 
         EXPECT_EQ(OK, player.api->poser_corde(2, dir));
         EXPECT_EQ(true, player.api->corde_sur_case(
                             player.api->info_nain(player_id, 0).pos));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         // The third dwarf moves the rope up
         EXPECT_EQ(OK, player.api->tirer(2, dir, HAUT));
         EXPECT_EQ(player.api->info_nain(player_id, 0).pos.ligne,
                   player.api->info_nain(player_id, 1).pos.ligne + 1);
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         // The third dwarf moves the rope down
         EXPECT_EQ(OK, player.api->tirer(2, dir, BAS));
         EXPECT_EQ(player.api->info_nain(player_id, 0).pos,
                   player.api->info_nain(player_id, 1).pos);
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         // Witch puts him at the bottom of the map ...
         EXPECT_EQ(OK, player.api->tirer(2, dir, BAS));
         EXPECT_EQ(OK, player.api->tirer(2, dir, BAS));
         EXPECT_EQ(player.api->info_nain(player_id, 0).pos,
                   player.api->info_nain(player_id, 1).pos);
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         // This is the same when moving as far as possible to top
         EXPECT_EQ(OK, player.api->tirer(2, dir, HAUT));
         EXPECT_EQ(OK, player.api->tirer(2, dir, HAUT));
         EXPECT_EQ(OK, player.api->tirer(2, dir, HAUT));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
         EXPECT_EQ(nain_initial.pos.ligne,
                   player.api->info_nain(player_id, 1).pos.ligne);
 
         EXPECT_EQ(OK, player.api->tirer(2, dir, HAUT));
         EXPECT_EQ(nain_initial.pos.ligne,
                   player.api->info_nain(player_id, 1).pos.ligne);
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
     }
 }
 
@@ -107,41 +107,41 @@ TEST_F(ApiTest, MergeCorde)
         for (int i = 0; i < 2; i++)
         {
             EXPECT_EQ(OK, player.api->miner(0, BAS));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
 
         while (OK == player.api->miner(0, reverse_direction(dir)))
             // I put a mineral on wanted direction, it takes time to break it
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->poser_corde(0, reverse_direction(dir)));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         // The first dwarf goes in a hole under the rope
         EXPECT_EQ(OK, player.api->deplacer(0, reverse_direction(dir)));
         EXPECT_EQ(OK, player.api->miner(0, BAS));
         EXPECT_EQ(OK, player.api->agripper(0));
 
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
-        player.api->game_state()->reset_pm(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
+        player.api->game_state().reset_pm(
+            player.api->game_state().get_player_id(player_id));
 
         // The second dwarf puts a rope and then digs a hole above the first one
         EXPECT_EQ(OK, player.api->poser_corde(1, dir));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->deplacer(1, dir));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->miner(1, BAS));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(player.api->info_nain(player_id, 0).pos,
                   player.api->info_nain(player_id, 1).pos);

--- a/src/tests/test-annuler.cc
+++ b/src/tests/test-annuler.cc
@@ -6,18 +6,17 @@
 #define CHECK_CANCEL_HISTORY_SIZE(player, action)                              \
     {                                                                          \
         const int player_id__ =                                                \
-            player.api->game_state()->get_player_id(player.api->moi());        \
-        const size_t history_size = player.api->game_state()                   \
-                                        ->get_internal_history(player_id__)    \
-                                        .size();                               \
+            player.api->game_state().get_player_id(player.api->moi());         \
+        const size_t history_size =                                            \
+            player.api->game_state().get_internal_history(player_id__).size(); \
                                                                                \
         action;                                                                \
         EXPECT_NE(history_size, player.api->game_state()                       \
-                                    ->get_internal_history(player_id__)        \
+                                    .get_internal_history(player_id__)         \
                                     .size());                                  \
-        player.api->annuler();                                                 \
+        player.api->cancel();                                                  \
         EXPECT_EQ(history_size, player.api->game_state()                       \
-                                    ->get_internal_history(player_id__)        \
+                                    .get_internal_history(player_id__)         \
                                     .size());                                  \
     }
 
@@ -27,7 +26,7 @@
             player.api->info_nain(player.api->moi(), nain_id);                 \
                                                                                \
         action;                                                                \
-        EXPECT_EQ(true, player.api->annuler());                                \
+        EXPECT_EQ(true, player.api->cancel());                                 \
                                                                                \
         EXPECT_EQ(nain_before_.pos,                                            \
                   player.api->info_nain(player.api->moi(), nain_id).pos);      \
@@ -45,27 +44,27 @@
 
 #define CHECK_CANCEL_ON_MAP(player, action)                                    \
     {                                                                          \
-        const Map map_before_ = player.api->game_state()->map();               \
+        const Map map_before_ = player.api->game_state().map();                \
                                                                                \
         action;                                                                \
-        EXPECT_EQ(true, player.api->annuler());                                \
+        EXPECT_EQ(true, player.api->cancel());                                 \
                                                                                \
         for (int row = 0; row < TAILLE_MINE; row++)                            \
             for (int col = 0; col < TAILLE_MINE; col++)                        \
             {                                                                  \
                 EXPECT_EQ(map_before_.get_minerai_at({row, col}).resistance,   \
                           player.api->game_state()                             \
-                              ->map()                                          \
+                              .map()                                           \
                               .get_minerai_at({row, col})                      \
                               .resistance);                                    \
                 EXPECT_EQ(map_before_.get_minerai_at({row, col}).rendement,    \
                           player.api->game_state()                             \
-                              ->map()                                          \
+                              .map()                                           \
                               .get_minerai_at({row, col})                      \
                               .rendement);                                     \
-                EXPECT_EQ(map_before_.get_cell_type({row, col}),               \
-                          player.api->game_state()->map().get_cell_type(       \
-                              {row, col}));                                    \
+                EXPECT_EQ(                                                     \
+                    map_before_.get_cell_type({row, col}),                     \
+                    player.api->game_state().map().get_cell_type({row, col})); \
             }                                                                  \
     }
 
@@ -92,11 +91,11 @@ TEST_F(ApiTest, Annuler_EmptyHist)
             EXPECT_EQ(OK, player.api->deplacer(nain_id, dir));
             EXPECT_EQ(OK, player.api->deplacer(nain_id, dir));
 
-            EXPECT_EQ(true, player.api->annuler());
-            EXPECT_EQ(true, player.api->annuler());
-            EXPECT_EQ(true, player.api->annuler());
-            EXPECT_EQ(false, player.api->annuler());
-            EXPECT_EQ(false, player.api->annuler());
+            EXPECT_EQ(true, player.api->cancel());
+            EXPECT_EQ(true, player.api->cancel());
+            EXPECT_EQ(true, player.api->cancel());
+            EXPECT_EQ(false, player.api->cancel());
+            EXPECT_EQ(false, player.api->cancel());
         }
     }
 }
@@ -142,14 +141,14 @@ TEST_F(ApiTest, Annuler_Miner)
             // The bottom mineral has 5 hit points
             for (int i = 0; i < 5; i++)
             {
-                player.api->game_state()->reset_pa(
-                    player.api->game_state()->get_player_id(player_id));
+                player.api->game_state().reset_pa(
+                    player.api->game_state().get_player_id(player_id));
 
                 CHECK_CANCEL(player, player.api->miner(nain_id, BAS));
                 EXPECT_EQ(OK, player.api->miner(nain_id, BAS));
             }
 
-            while (player.api->annuler())
+            while (player.api->cancel())
                 ;
         }
     }
@@ -169,8 +168,8 @@ TEST_F(ApiTest, Annuler_Chute)
         for (int i = 0; i < 3; i++)
         {
             EXPECT_EQ(OK, player.api->miner(0, BAS));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
 
         // SECOND DWARF DO THE FLOP
@@ -180,8 +179,8 @@ TEST_F(ApiTest, Annuler_Chute)
         for (int i = 0; i < 10; i++)
         {
             EXPECT_EQ(OK, player.api->miner(0, BAS));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
 
         // SECOND DWARF DO THE (DEADLY) FLOP
@@ -200,8 +199,8 @@ TEST_F(ApiTest, Annuler_ActionsCorde)
         // The first dwarf digs a hole on right with a rope on it
         CHECK_CANCEL(player, player.api->poser_corde(0, dir));
         EXPECT_EQ(OK, player.api->poser_corde(0, dir));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->deplacer(0, dir));
 
@@ -209,35 +208,35 @@ TEST_F(ApiTest, Annuler_ActionsCorde)
         {
             CHECK_CANCEL(player, player.api->miner(0, BAS));
             EXPECT_EQ(OK, player.api->miner(0, BAS));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
 
         // The first dwarf extends the rope with another one
         EXPECT_EQ(OK, player.api->miner(0, dir));
         EXPECT_EQ(OK, player.api->deplacer(0, dir));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->miner(0, dir));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->miner(0, BAS));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->miner(0, BAS));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->miner(0, reverse_direction(dir)));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->poser_corde(0, reverse_direction(dir)));
-        player.api->game_state()->reset_pa(
-            player.api->game_state()->get_player_id(player_id));
+        player.api->game_state().reset_pa(
+            player.api->game_state().get_player_id(player_id));
 
         EXPECT_EQ(OK, player.api->deplacer(0, reverse_direction(dir)));
 
@@ -254,8 +253,8 @@ TEST_F(ApiTest, Annuler_ActionsCorde)
         {
             CHECK_CANCEL(player, player.api->tirer(1, dir, HAUT));
             EXPECT_EQ(OK, player.api->tirer(1, dir, HAUT));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
     }
 }
@@ -278,8 +277,8 @@ TEST_F(ApiTest, Cancel_HitAllie)
         {
             CHECK_CANCEL(player, player.api->miner(0, reverse_direction(dir)));
             EXPECT_EQ(OK, player.api->miner(0, reverse_direction(dir)));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
 
         EXPECT_EQ(PAS_DE_CIBLE, player.api->miner(0, reverse_direction(dir)));
@@ -297,8 +296,8 @@ TEST_F(ApiTest, Cancel_HitEnemie)
         for (int i = 0; i < TAILLE_MINE - 2; i++)
         {
             EXPECT_EQ(OK, player.api->deplacer(0, dir));
-            player.api->game_state()->reset_pm(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pm(
+                player.api->game_state().get_player_id(player_id));
         }
 
         EXPECT_EQ(OBSTACLE_NAIN, player.api->deplacer(0, dir));
@@ -311,8 +310,8 @@ TEST_F(ApiTest, Cancel_HitEnemie)
         {
             CHECK_CANCEL(player, player.api->miner(0, dir));
             EXPECT_EQ(OK, player.api->miner(0, dir));
-            player.api->game_state()->reset_pa(
-                player.api->game_state()->get_player_id(player_id));
+            player.api->game_state().reset_pa(
+                player.api->game_state().get_player_id(player_id));
         }
 
         EXPECT_EQ(PAS_DE_CIBLE, player.api->miner(0, reverse_direction(dir)));

--- a/src/tests/test-api.cc
+++ b/src/tests/test-api.cc
@@ -23,8 +23,10 @@ TEST_F(ApiTest, Api_TourActuel)
     for (int round = 0; round < NB_TOURS; round++)
     {
         for (auto& player : players)
+        {
             EXPECT_EQ(round, player.api->tour_actuel());
-        st->increment_round();
+            player.api->game_state().increment_round();
+        }
     }
 }
 
@@ -150,7 +152,7 @@ TEST_F(ApiTest, Api_annuler)
 {
     for (auto& player : players)
     {
-        EXPECT_EQ(player.api->annuler(), false);
+        EXPECT_EQ(player.api->cancel(), false);
     }
 }
 

--- a/src/tests/test-helpers.hh
+++ b/src/tests/test-helpers.hh
@@ -77,12 +77,11 @@ protected:
     virtual void SetUp()
     {
         utils::Logger::get().level() = utils::Logger::DEBUG_LEVEL;
-        st = make_test_gamestate(test_map, make_players(PLAYER_1, PLAYER_2));
+        st.reset(
+            make_test_gamestate(test_map, make_players(PLAYER_1, PLAYER_2)));
     }
 
-    virtual void TearDown() { delete st; }
-
-    GameState* st;
+    std::unique_ptr<GameState> st;
 
     const int PLAYER_1 = 0;
     const int PLAYER_2 = 1;
@@ -99,27 +98,22 @@ protected:
 
         utils::Logger::get().level() = utils::Logger::DEBUG_LEVEL;
         auto players_ptr = make_players(player_id_1, player_id_2);
-        st = make_test_gamestate(test_map, players_ptr);
+        std::unique_ptr<GameState> st(
+            make_test_gamestate(test_map, players_ptr));
         st->set_init(true);
 
         players[0].id = player_id_1;
-        players[0].api = new Api(st, players_ptr->players[0]);
+        players[0].api = std::make_unique<Api>(
+            std::unique_ptr<GameState>(st->copy()), players_ptr->players[0]);
         players[1].id = player_id_2;
-        players[1].api = new Api(st, players_ptr->players[1]);
+        players[1].api = std::make_unique<Api>(
+            std::unique_ptr<GameState>(st->copy()), players_ptr->players[1]);
     }
-
-    virtual void TearDown()
-    {
-        delete players[0].api;
-        delete players[1].api;
-    }
-
-    GameState* st;
 
     struct Player
     {
         int id;
-        Api* api;
+        std::unique_ptr<Api> api;
     };
     std::array<Player, 2> players;
 };

--- a/src/tests/test-rules.cc
+++ b/src/tests/test-rules.cc
@@ -15,7 +15,7 @@ TEST_F(RulesTest, Rules_Finish)
         rules->start_of_player_turn(PLAYER_ID_2);
         rules->end_of_player_turn(PLAYER_ID_2);
 
-        EXPECT_EQ(round, rules->get_game_state()->get_round());
+        EXPECT_EQ(round, rules->get_game_state().get_round());
         rules->end_of_round();
 
         round++;


### PR DESCRIPTION
Note that the ApiActionFunc functor could not be used because of the extra:

    const int player_id = game_state_->get_player_id(player_->id);

that the api does before creating the action.

I'm thinking about how to avoid having to do that, which would allow cutting down the boilerplate.